### PR TITLE
Add Angular 2+

### DIFF
--- a/angular.ts
+++ b/angular.ts
@@ -1,0 +1,15 @@
+import { Component, AfterViewInit } from '@angular/core';
+import { Elm } from '../dist/elm/main';
+
+@Component({
+  selector: 'elm-embed',
+  template: '<div id="elm-embed"></div>',
+})
+export class ElmComponent implements AfterViewInit {
+  ngAfterViewInit() {
+    const app = Elm.Main.init({
+      node: document.getElementById('elm-embed'),
+    });
+    // set up ports however you want
+  }
+}


### PR DESCRIPTION
Here's an integration based on Angular 6.

I tested this by adding a "hello world" Elm 0.19 `Browser.element` app into the demo from the Angular tutorial.

The repo should probably have separate examples for "AngularJS" (v1) and "Angular" (v2+) because they're so different. Filenames like `angularjs.js` and `angular.ts` should be enough to distinguish them clearly. This PR is for v2+ only.